### PR TITLE
Properly link and bundle gstreamer dependencies for Android

### DIFF
--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -35,6 +35,8 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
+            isMinifyEnabled = false
+            isShrinkResources = false
         }
     }
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:label="flutter_realtime_player_example"
         android:name="${applicationName}"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -317,10 +317,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   native_toolchain_rust:
     dependency: transitive
     description:
@@ -482,10 +482,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   toml:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -301,10 +301,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -474,10 +474,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.10"
   toml:
     dependency: transitive
     description:

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -42,7 +42,10 @@ void main(List<String> args) async {
         'GSTREAMER_1_0_ROOT_MSVC_X86_64': envFile.getString(
           'GSTREAMER_1_0_ROOT_MSVC_X86_64',
         ),
-        'PKG_CONFIG_PATH': envFile.getString('PKG_CONFIG_PATH') ?? '',
+        'PKG_CONFIG_PATH': envFile.getString(
+          'PKG_CONFIG_PATH',
+          defaultValue: '',
+        ),
       },
     ).run(input: input, output: output);
 

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -37,7 +37,7 @@ void main(List<String> args) async {
         ),
         _pkgConfigSysrootx8664EnvVar: pkgConfigSysrootDir ?? '',
         _pkgConfigSysrootAarch64EnvVar: pkgConfigSysrootDir ?? '',
-        _androidNDKHomeEnvVar: ndkPrebuiltRoot ?? '',
+        _androidNDKHomeEnvVar: ndkHome,
         // Pass Windows GStreamer environment variables if present
         'GSTREAMER_1_0_ROOT_MSVC_X86_64': envFile.getString(
           'GSTREAMER_1_0_ROOT_MSVC_X86_64',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -390,10 +390,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -611,10 +611,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.10"
   toml:
     dependency: transitive
     description:

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -66,8 +66,94 @@ fn main() {
 
         // gstreamer-video
         println!("cargo:rustc-link-lib=static=gstvideo-1.0");
+        println!("cargo:rustc-link-lib=static=gstgl-1.0");             // GL symbols pulled in by androidmedia/videoconvert
+        println!("cargo:rustc-link-lib=static=gstcodecparsers-1.0"); // H.264/H.265/etc. bitstream parsers
+        println!("cargo:rustc-link-lib=static=gstcodecs-1.0");       // codec helpers (used by androidmedia, videoparsersbad)
+        println!("cargo:rustc-link-lib=static=gstpbutils-1.0");      // playback utils (used by playbin3)
+        println!("cargo:rustc-link-lib=static=gsttag-1.0");          // tag reading (used by demuxers)
+        println!("cargo:rustc-link-lib=static=gstriff-1.0");          // RIFF parsing (pulled in by libav/demuxers)
+        println!("cargo:rustc-link-lib=static=gstrtp-1.0");          // RTP base (used by rtp plugins)
+        println!("cargo:rustc-link-lib=static=gstrtsp-1.0");         // RTSP base
+        println!("cargo:rustc-link-lib=static=gstsdp-1.0");          // SDP parsing
+        println!("cargo:rustc-link-lib=static=gstallocators-1.0");     // dmabuf/EGL allocators (pulled in by androidmedia/gl)
+        println!("cargo:rustc-link-lib=static=gstnet-1.0");            // network clock (pulled in by rtsp/pipeline)
+        println!("cargo:rustc-link-lib=static=gstisoff-1.0");        // ISO fragment parsing (DASH/HLS)
 
         println!("cargo:rustc-link-lib=static=gmodule-2.0"); // For g_module_open
+
+        // --- GStreamer plugins (must be statically linked on Android) ---
+
+        // Core: without these, NO elements work at all
+        println!("cargo:rustc-link-lib=static=gstcoreelements");   // filesrc, fakesink, queue, etc.
+        println!("cargo:rustc-link-lib=static=gsttypefindfunctions"); // format auto-detection
+        println!("cargo:rustc-link-lib=static=gstplayback");        // playbin3 itself
+
+        // Networking / HTTP(S) source
+        println!("cargo:rustc-link-lib=static=gstsoup");            // souphttpsrc for http(s)://
+        println!("cargo:rustc-link-lib=static=soup-3.0");
+        println!("cargo:rustc-link-lib=static=gio-2.0");
+        println!("cargo:rustc-link-lib=static=ssl");
+        println!("cargo:rustc-link-lib=static=crypto");
+        println!("cargo:rustc-link-lib=static=nghttp2");
+        println!("cargo:rustc-link-lib=static=psl");
+        println!("cargo:rustc-link-lib=static=z");
+        println!("cargo:rustc-link-lib=static=bz2");
+
+        // Demuxers
+        println!("cargo:rustc-link-lib=static=gstmatroska");        // WebM / MKV
+        println!("cargo:rustc-link-lib=static=gstisomp4");          // MP4 / MOV
+
+        // Software decoders (ffmpeg-based, covers VP8/VP9/H264/H265/AAC/etc.)
+        println!("cargo:rustc-link-lib=static=gstlibav");
+        println!("cargo:rustc-link-lib=static=avcodec");
+        println!("cargo:rustc-link-lib=static=avformat");
+        println!("cargo:rustc-link-lib=static=avfilter");
+        println!("cargo:rustc-link-lib=static=avutil");
+        println!("cargo:rustc-link-lib=static=swresample");
+        println!("cargo:rustc-link-lib=static=swscale");
+        println!("cargo:rustc-link-lib=static=x264");
+
+        // Native VP8/VP9 decoder (lighter than libav for WebM)
+        println!("cargo:rustc-link-lib=static=gstvpx");
+        println!("cargo:rustc-link-lib=static=vpx");
+
+        // Android hardware decoder (MediaCodec)
+        println!("cargo:rustc-link-lib=static=gstandroidmedia");
+
+        // Video color conversion (RGBA output from NV12/I420/etc.)
+        println!("cargo:rustc-link-lib=static=gstvideoconvertscale");
+
+        // Audio (needed by playbin3 even if muted)
+        println!("cargo:rustc-link-lib=static=gstaudioconvert");
+        println!("cargo:rustc-link-lib=static=gstaudioresample");
+        println!("cargo:rustc-link-lib=static=gstvolume");
+        println!("cargo:rustc-link-lib=static=gstaudiomixer");
+        println!("cargo:rustc-link-lib=static=gstaudio-1.0");
+
+        // Autodetect sinks (playbin3 uses these for audio/video sink selection)
+        println!("cargo:rustc-link-lib=static=gstautodetect");
+
+        // Audio/video parsers
+        println!("cargo:rustc-link-lib=static=gstaudioparsers");
+        println!("cargo:rustc-link-lib=static=gstvideoparsersbad");
+
+        // RTSP/RTP/UDP/TCP/SDP (required for rtsp:// and rtp:// URIs)
+        println!("cargo:rustc-link-lib=static=gstrtsp");
+        println!("cargo:rustc-link-lib=static=gstrtp");
+        println!("cargo:rustc-link-lib=static=gstrtpmanager");
+        println!("cargo:rustc-link-lib=static=gstudp");
+        println!("cargo:rustc-link-lib=static=gsttcp");
+        println!("cargo:rustc-link-lib=static=gstsdpelem");
+
+        // Photography plugin — pulled in by androidmedia at link time
+        println!("cargo:rustc-link-lib=static=gstphotography-1.0");
+
+        // Android audio sink
+        println!("cargo:rustc-link-lib=static=gstopensles");
+        println!("cargo:rustc-link-lib=OpenSLES"); // Android system OpenSL ES
+        // Android system libs required by GStreamer (always present on device)
+        println!("cargo:rustc-link-lib=atomic");
+        println!("cargo:rustc-link-lib=log");
 
         println!("cargo:rustc-link-arg=-Wl,--allow-multiple-definition"); // for JNI_OnLoad conflicts
     }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -66,30 +66,30 @@ fn main() {
 
         // gstreamer-video
         println!("cargo:rustc-link-lib=static=gstvideo-1.0");
-        println!("cargo:rustc-link-lib=static=gstgl-1.0");             // GL symbols pulled in by androidmedia/videoconvert
-        println!("cargo:rustc-link-lib=static=gstcodecparsers-1.0"); // H.264/H.265/etc. bitstream parsers
-        println!("cargo:rustc-link-lib=static=gstcodecs-1.0");       // codec helpers (used by androidmedia, videoparsersbad)
-        println!("cargo:rustc-link-lib=static=gstpbutils-1.0");      // playback utils (used by playbin3)
-        println!("cargo:rustc-link-lib=static=gsttag-1.0");          // tag reading (used by demuxers)
-        println!("cargo:rustc-link-lib=static=gstriff-1.0");          // RIFF parsing (pulled in by libav/demuxers)
-        println!("cargo:rustc-link-lib=static=gstrtp-1.0");          // RTP base (used by rtp plugins)
-        println!("cargo:rustc-link-lib=static=gstrtsp-1.0");         // RTSP base
-        println!("cargo:rustc-link-lib=static=gstsdp-1.0");          // SDP parsing
-        println!("cargo:rustc-link-lib=static=gstallocators-1.0");     // dmabuf/EGL allocators (pulled in by androidmedia/gl)
-        println!("cargo:rustc-link-lib=static=gstnet-1.0");            // network clock (pulled in by rtsp/pipeline)
-        println!("cargo:rustc-link-lib=static=gstisoff-1.0");        // ISO fragment parsing (DASH/HLS)
+        println!("cargo:rustc-link-lib=static=gstgl-1.0");
+        println!("cargo:rustc-link-lib=static=gstcodecparsers-1.0");
+        println!("cargo:rustc-link-lib=static=gstcodecs-1.0");
+        println!("cargo:rustc-link-lib=static=gstpbutils-1.0");
+        println!("cargo:rustc-link-lib=static=gsttag-1.0");
+        println!("cargo:rustc-link-lib=static=gstriff-1.0");
+        println!("cargo:rustc-link-lib=static=gstrtp-1.0");
+        println!("cargo:rustc-link-lib=static=gstrtsp-1.0");
+        println!("cargo:rustc-link-lib=static=gstsdp-1.0");
+        println!("cargo:rustc-link-lib=static=gstallocators-1.0");
+        println!("cargo:rustc-link-lib=static=gstnet-1.0");
+        println!("cargo:rustc-link-lib=static=gstisoff-1.0");
 
-        println!("cargo:rustc-link-lib=static=gmodule-2.0"); // For g_module_open
+        println!("cargo:rustc-link-lib=static=gmodule-2.0");
 
         // --- GStreamer plugins (must be statically linked on Android) ---
 
         // Core: without these, NO elements work at all
-        println!("cargo:rustc-link-lib=static=gstcoreelements");   // filesrc, fakesink, queue, etc.
-        println!("cargo:rustc-link-lib=static=gsttypefindfunctions"); // format auto-detection
-        println!("cargo:rustc-link-lib=static=gstplayback");        // playbin3 itself
+        println!("cargo:rustc-link-lib=static=gstcoreelements");
+        println!("cargo:rustc-link-lib=static=gsttypefindfunctions");
+        println!("cargo:rustc-link-lib=static=gstplayback");
 
         // Networking / HTTP(S) source
-        println!("cargo:rustc-link-lib=static=gstsoup");            // souphttpsrc for http(s)://
+        println!("cargo:rustc-link-lib=static=gstsoup");
         println!("cargo:rustc-link-lib=static=soup-3.0");
         println!("cargo:rustc-link-lib=static=gio-2.0");
         println!("cargo:rustc-link-lib=static=ssl");
@@ -98,10 +98,6 @@ fn main() {
         println!("cargo:rustc-link-lib=static=psl");
         println!("cargo:rustc-link-lib=static=z");
         println!("cargo:rustc-link-lib=static=bz2");
-
-        // Demuxers
-        println!("cargo:rustc-link-lib=static=gstmatroska");        // WebM / MKV
-        println!("cargo:rustc-link-lib=static=gstisomp4");          // MP4 / MOV
 
         // Software decoders (ffmpeg-based, covers VP8/VP9/H264/H265/AAC/etc.)
         println!("cargo:rustc-link-lib=static=gstlibav");
@@ -112,10 +108,6 @@ fn main() {
         println!("cargo:rustc-link-lib=static=swresample");
         println!("cargo:rustc-link-lib=static=swscale");
         println!("cargo:rustc-link-lib=static=x264");
-
-        // Native VP8/VP9 decoder (lighter than libav for WebM)
-        println!("cargo:rustc-link-lib=static=gstvpx");
-        println!("cargo:rustc-link-lib=static=vpx");
 
         // Android hardware decoder (MediaCodec)
         println!("cargo:rustc-link-lib=static=gstandroidmedia");
@@ -132,10 +124,6 @@ fn main() {
 
         // Autodetect sinks (playbin3 uses these for audio/video sink selection)
         println!("cargo:rustc-link-lib=static=gstautodetect");
-
-        // Audio/video parsers
-        println!("cargo:rustc-link-lib=static=gstaudioparsers");
-        println!("cargo:rustc-link-lib=static=gstvideoparsersbad");
 
         // RTSP/RTP/UDP/TCP/SDP (required for rtsp:// and rtp:// URIs)
         println!("cargo:rustc-link-lib=static=gstrtsp");

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -84,6 +84,7 @@ fn main() {
         // --- GStreamer plugins (must be statically linked on Android) ---
 
         // Core: without these, NO elements work at all
+        println!("cargo:rustc-link-lib=static=gstapp");
         println!("cargo:rustc-link-lib=static=gstcoreelements");
         println!("cargo:rustc-link-lib=static=gsttypefindfunctions");
         println!("cargo:rustc-link-lib=static=gstplayback");
@@ -132,6 +133,7 @@ fn main() {
         println!("cargo:rustc-link-lib=static=gstudp");
         println!("cargo:rustc-link-lib=static=gsttcp");
         println!("cargo:rustc-link-lib=static=gstsdpelem");
+        println!("cargo:rustc-link-lib=static=gstvideoparsersbad");
 
         // Photography plugin — pulled in by androidmedia at link time
         println!("cargo:rustc-link-lib=static=gstphotography-1.0");

--- a/rust/src/api/simple.rs
+++ b/rust/src/api/simple.rs
@@ -30,6 +30,11 @@ pub fn flutter_realtime_player_init(ffi_ptr: i64) {
     irondash_dart_ffi::irondash_init_ffi(ffi_ptr as *mut std::ffi::c_void);
 
     registry::init().log_err();
+    // it is necessary for Android to register all plugins manually since we are linking statically
+    #[cfg(target_os = "android")]
+    unsafe {
+        crate::android_gst_plugins::register_all();
+    }
     thread::spawn(crate::core::session::registry::stream_alive_tester_task);
     debug!("Done initializing flutter gstreamer");
     *is_initialized = true;
@@ -64,7 +69,11 @@ pub async fn create_playable(
             let (session, shutdown_rx) =
                 WscRtpSession::new(wsc_rtp_config, session_common, HTTP_CLIENT.clone());
             let session_clone = session.clone();
-            tokio::spawn(async move { session_clone.execute(shutdown_rx).await });
+            tokio::spawn(async move {
+                if let Err(e) = session_clone.execute(shutdown_rx).await {
+                    log::error!("WscRtp session {} exited with error: {}", session_id, e);
+                }
+            });
             insert_session(session_id, session);
         }
         VideoConfig::Playbin(playbin_config) => {
@@ -72,7 +81,11 @@ pub async fn create_playable(
             let session_common = VideoSessionCommon::new(session_id, engine_handle, combined_sink);
             let (session, shutdown_rx) = PlaybinSession::new(playbin_config, session_common);
             let session_clone = session.clone();
-            tokio::spawn(async move { session_clone.execute(shutdown_rx).await });
+            tokio::spawn(async move {
+                if let Err(e) = session_clone.execute(shutdown_rx).await {
+                    log::error!("Playbin session {} exited with error: {}", session_id, e);
+                }
+            });
             insert_session(session_id, session);
         }
     }

--- a/rust/src/core/input/playbin.rs
+++ b/rust/src/core/input/playbin.rs
@@ -48,7 +48,7 @@ impl PlaybinSession {
 
     pub async fn execute(
         self: &Arc<Self>,
-        mut shutdown_rx: tokio::sync::mpsc::Receiver<()>,
+        shutdown_rx: tokio::sync::mpsc::Receiver<()>,
     ) -> anyhow::Result<()> {
         let payload_holder = Arc::new(payload::PayloadHolder::new());
         let payload_holder_weak = Arc::downgrade(&payload_holder);
@@ -64,9 +64,40 @@ impl PlaybinSession {
                 Ok((texture.into_sendable_texture(), texture_id))
             })?;
 
+        // Run the inner pipeline setup + event loop in a separate async fn.
+        // This ensures that regardless of how the inner function exits (including
+        // early returns via `?`), we always drop sendable_texture and payload_holder
+        // on the platform main thread rather than on the tokio worker thread.
+        // Dropping sendable_texture off the main thread causes `unregisterTexture`
+        // to be called from a background thread, which crashes on Android.
+        let inner_result = self
+            .run_pipeline(
+                shutdown_rx,
+                Arc::downgrade(&sendable_texture),
+                texture_id,
+                payload_holder_weak,
+            )
+            .await;
+
+        invoke_on_platform_main_thread(move || {
+            drop(sendable_texture);
+            drop(payload_holder);
+        });
+
+        inner_result
+    }
+
+    async fn run_pipeline(
+        self: &Arc<Self>,
+        mut shutdown_rx: tokio::sync::mpsc::Receiver<()>,
+        weak_texture: crate::core::texture::flutter::WeakSendableTexture,
+        texture_id: i64,
+        payload_holder_weak: std::sync::Weak<payload::PayloadHolder>,
+    ) -> anyhow::Result<()> {
+
         let texture_session = Arc::new(crate::core::texture::flutter::TextureSession::new(
             texture_id,
-            Arc::downgrade(&sendable_texture),
+            weak_texture,
             payload_holder_weak.clone(),
         ));
         let texture_session: Arc<dyn FlutterTextureSession> = texture_session;
@@ -279,13 +310,6 @@ impl PlaybinSession {
 
         // Send Stopped state
         let _ = self.session_common.send_state_msg(StreamState::Stopped);
-
-        // Texture + payload_holder must always be dropped on the platform main thread,
-        // regardless of how the loop exited (including error paths).
-        crate::utils::invoke_on_platform_main_thread(move || {
-            drop(sendable_texture);
-            drop(payload_holder);
-        });
 
         loop_result
     }

--- a/rust/src/core/input/playbin.rs
+++ b/rust/src/core/input/playbin.rs
@@ -64,12 +64,7 @@ impl PlaybinSession {
                 Ok((texture.into_sendable_texture(), texture_id))
             })?;
 
-        // Run the inner pipeline setup + event loop in a separate async fn.
-        // This ensures that regardless of how the inner function exits (including
-        // early returns via `?`), we always drop sendable_texture and payload_holder
-        // on the platform main thread rather than on the tokio worker thread.
-        // Dropping sendable_texture off the main thread causes `unregisterTexture`
-        // to be called from a background thread, which crashes on Android.
+        // This will ensure that we only destroy the texture on platform main thread
         let inner_result = self
             .run_pipeline(
                 shutdown_rx,

--- a/rust/src/core/input/wsc_rtp.rs
+++ b/rust/src/core/input/wsc_rtp.rs
@@ -913,12 +913,12 @@ fn build_pipeline_str(encoding: &str, pt: u8, clock_rate: u32, sprop: &Option<St
         sprop.is_some()
     );
     let depay_decode = match encoding {
-        "H264" => "rtph264depay ! h264parse ! avdec_h264",
-        "H265" | "HEVC" => "rtph265depay ! h265parse ! avdec_h265",
-        "VP8" => "rtpvp8depay ! vp8dec",
-        "VP9" => "rtpvp9depay ! vp9dec",
-        _ => "rtpjpegdepay ! jpegdec",
-    };
+    "H264" => "rtph264depay ! h264parse ! decodebin",
+    "H265" | "HEVC" => "rtph265depay ! h265parse ! decodebin",
+    "VP8" => "rtpvp8depay ! decodebin",
+    "VP9" => "rtpvp9depay ! decodebin",
+    _ => "rtpjpegdepay ! jpegdec",
+};
 
     let caps_str = build_rtp_caps_str(encoding, pt, clock_rate, sprop);
     let escaped_caps = caps_str.replace('"', "\\\"");

--- a/rust/src/core/input/wsc_rtp.rs
+++ b/rust/src/core/input/wsc_rtp.rs
@@ -288,7 +288,7 @@ impl WscRtpSession {
                     }
                 }
                 Err(e) => {
-                    error!("WSC-RTP connection failed: {}", e);
+                    error!("WSC-RTP connection failed: {:#}", e);
                     self.session_common
                         .send_event_msg(StreamEvent::Error(format!("Connection failed: {}", e)));
 

--- a/rust/src/core/input/wsc_rtp.rs
+++ b/rust/src/core/input/wsc_rtp.rs
@@ -913,12 +913,12 @@ fn build_pipeline_str(encoding: &str, pt: u8, clock_rate: u32, sprop: &Option<St
         sprop.is_some()
     );
     let depay_decode = match encoding {
-    "H264" => "rtph264depay ! h264parse ! decodebin",
-    "H265" | "HEVC" => "rtph265depay ! h265parse ! decodebin",
-    "VP8" => "rtpvp8depay ! decodebin",
-    "VP9" => "rtpvp9depay ! decodebin",
-    _ => "rtpjpegdepay ! jpegdec",
-};
+        "H264" => "rtph264depay ! h264parse ! avdec_h264",
+        "H265" | "HEVC" => "rtph265depay ! h265parse ! avdec_h265",
+        "VP8" => "rtpvp8depay ! vp8dec",
+        "VP9" => "rtpvp9depay ! vp9dec",
+        _ => "rtpjpegdepay ! jpegdec",
+    };
 
     let caps_str = build_rtp_caps_str(encoding, pt, clock_rate, sprop);
     let escaped_caps = caps_str.replace('"', "\\\"");

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,6 +7,7 @@ pub mod utils;
 #[cfg(target_os = "android")]
 pub(crate) mod android_gst_plugins {
     extern "C" {
+        pub fn gst_plugin_app_register();
         pub fn gst_plugin_coreelements_register();
         pub fn gst_plugin_typefindfunctions_register();
         pub fn gst_plugin_playback_register();
@@ -26,9 +27,11 @@ pub(crate) mod android_gst_plugins {
         pub fn gst_plugin_udp_register();
         pub fn gst_plugin_tcp_register();
         pub fn gst_plugin_sdpelem_register();
+        pub fn gst_plugin_videoparsersbad_register();
     }
 
     pub unsafe fn register_all() {
+        gst_plugin_app_register();
         gst_plugin_coreelements_register();
         gst_plugin_typefindfunctions_register();
         gst_plugin_playback_register();
@@ -48,5 +51,6 @@ pub(crate) mod android_gst_plugins {
         gst_plugin_udp_register();
         gst_plugin_tcp_register();
         gst_plugin_sdpelem_register();
+        gst_plugin_videoparsersbad_register();
     }
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3,3 +3,60 @@ pub mod core;
 pub mod dart_types;
 mod frb_generated; /* AUTO INJECTED BY flutter_rust_bridge. This line may not be accurate, and you can change it according to your needs. */
 pub mod utils;
+
+#[cfg(target_os = "android")]
+pub(crate) mod android_gst_plugins {
+    extern "C" {
+        pub fn gst_plugin_coreelements_register();
+        pub fn gst_plugin_typefindfunctions_register();
+        pub fn gst_plugin_playback_register();
+        pub fn gst_plugin_soup_register();
+        pub fn gst_plugin_matroska_register();
+        pub fn gst_plugin_isomp4_register();
+        pub fn gst_plugin_libav_register();
+        pub fn gst_plugin_vpx_register();
+        pub fn gst_plugin_androidmedia_register();
+        pub fn gst_plugin_videoconvertscale_register();
+        pub fn gst_plugin_audioconvert_register();
+        pub fn gst_plugin_audioresample_register();
+        pub fn gst_plugin_volume_register();
+        pub fn gst_plugin_audiomixer_register();
+        pub fn gst_plugin_autodetect_register();
+        pub fn gst_plugin_audioparsers_register();
+        pub fn gst_plugin_videoparsersbad_register();
+        pub fn gst_plugin_opensles_register();
+        pub fn gst_plugin_rtsp_register();
+        pub fn gst_plugin_rtp_register();
+        pub fn gst_plugin_rtpmanager_register();
+        pub fn gst_plugin_udp_register();
+        pub fn gst_plugin_tcp_register();
+        pub fn gst_plugin_sdpelem_register();
+    }
+
+    pub unsafe fn register_all() {
+        gst_plugin_coreelements_register();
+        gst_plugin_typefindfunctions_register();
+        gst_plugin_playback_register();
+        gst_plugin_soup_register();
+        gst_plugin_matroska_register();
+        gst_plugin_isomp4_register();
+        gst_plugin_libav_register();
+        gst_plugin_vpx_register();
+        gst_plugin_androidmedia_register();
+        gst_plugin_videoconvertscale_register();
+        gst_plugin_audioconvert_register();
+        gst_plugin_audioresample_register();
+        gst_plugin_volume_register();
+        gst_plugin_audiomixer_register();
+        gst_plugin_autodetect_register();
+        gst_plugin_audioparsers_register();
+        gst_plugin_videoparsersbad_register();
+        gst_plugin_opensles_register();
+        gst_plugin_rtsp_register();
+        gst_plugin_rtp_register();
+        gst_plugin_rtpmanager_register();
+        gst_plugin_udp_register();
+        gst_plugin_tcp_register();
+        gst_plugin_sdpelem_register();
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -11,10 +11,7 @@ pub(crate) mod android_gst_plugins {
         pub fn gst_plugin_typefindfunctions_register();
         pub fn gst_plugin_playback_register();
         pub fn gst_plugin_soup_register();
-        pub fn gst_plugin_matroska_register();
-        pub fn gst_plugin_isomp4_register();
         pub fn gst_plugin_libav_register();
-        pub fn gst_plugin_vpx_register();
         pub fn gst_plugin_androidmedia_register();
         pub fn gst_plugin_videoconvertscale_register();
         pub fn gst_plugin_audioconvert_register();
@@ -22,8 +19,6 @@ pub(crate) mod android_gst_plugins {
         pub fn gst_plugin_volume_register();
         pub fn gst_plugin_audiomixer_register();
         pub fn gst_plugin_autodetect_register();
-        pub fn gst_plugin_audioparsers_register();
-        pub fn gst_plugin_videoparsersbad_register();
         pub fn gst_plugin_opensles_register();
         pub fn gst_plugin_rtsp_register();
         pub fn gst_plugin_rtp_register();
@@ -38,10 +33,7 @@ pub(crate) mod android_gst_plugins {
         gst_plugin_typefindfunctions_register();
         gst_plugin_playback_register();
         gst_plugin_soup_register();
-        gst_plugin_matroska_register();
-        gst_plugin_isomp4_register();
         gst_plugin_libav_register();
-        gst_plugin_vpx_register();
         gst_plugin_androidmedia_register();
         gst_plugin_videoconvertscale_register();
         gst_plugin_audioconvert_register();
@@ -49,8 +41,6 @@ pub(crate) mod android_gst_plugins {
         gst_plugin_volume_register();
         gst_plugin_audiomixer_register();
         gst_plugin_autodetect_register();
-        gst_plugin_audioparsers_register();
-        gst_plugin_videoparsersbad_register();
         gst_plugin_opensles_register();
         gst_plugin_rtsp_register();
         gst_plugin_rtp_register();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,27 +7,27 @@ pub mod utils;
 #[cfg(target_os = "android")]
 pub(crate) mod android_gst_plugins {
     extern "C" {
-        pub fn gst_plugin_app_register();
-        pub fn gst_plugin_coreelements_register();
-        pub fn gst_plugin_typefindfunctions_register();
-        pub fn gst_plugin_playback_register();
-        pub fn gst_plugin_soup_register();
-        pub fn gst_plugin_libav_register();
-        pub fn gst_plugin_androidmedia_register();
-        pub fn gst_plugin_videoconvertscale_register();
-        pub fn gst_plugin_audioconvert_register();
-        pub fn gst_plugin_audioresample_register();
-        pub fn gst_plugin_volume_register();
-        pub fn gst_plugin_audiomixer_register();
-        pub fn gst_plugin_autodetect_register();
-        pub fn gst_plugin_opensles_register();
-        pub fn gst_plugin_rtsp_register();
-        pub fn gst_plugin_rtp_register();
-        pub fn gst_plugin_rtpmanager_register();
-        pub fn gst_plugin_udp_register();
-        pub fn gst_plugin_tcp_register();
-        pub fn gst_plugin_sdpelem_register();
-        pub fn gst_plugin_videoparsersbad_register();
+        pub fn gst_plugin_app_register() -> i32;
+        pub fn gst_plugin_coreelements_register() -> i32;
+        pub fn gst_plugin_typefindfunctions_register() -> i32;
+        pub fn gst_plugin_playback_register() -> i32;
+        pub fn gst_plugin_soup_register() -> i32;
+        pub fn gst_plugin_libav_register() -> i32;
+        pub fn gst_plugin_androidmedia_register() -> i32;
+        pub fn gst_plugin_videoconvertscale_register() -> i32;
+        pub fn gst_plugin_audioconvert_register() -> i32;
+        pub fn gst_plugin_audioresample_register() -> i32;
+        pub fn gst_plugin_volume_register() -> i32;
+        pub fn gst_plugin_audiomixer_register() -> i32;
+        pub fn gst_plugin_autodetect_register() -> i32;
+        pub fn gst_plugin_opensles_register() -> i32;
+        pub fn gst_plugin_rtsp_register() -> i32;
+        pub fn gst_plugin_rtp_register() -> i32;
+        pub fn gst_plugin_rtpmanager_register() -> i32;
+        pub fn gst_plugin_udp_register() -> i32;
+        pub fn gst_plugin_tcp_register() -> i32;
+        pub fn gst_plugin_sdpelem_register() -> i32;
+        pub fn gst_plugin_videoparsersbad_register() -> i32;
     }
 
     pub unsafe fn register_all() {


### PR DESCRIPTION
add missing GStreamer plugins to fix Playbin on Android
also make sure that Playbin destroy texture only calls from platform thread

<img width="812" height="831" alt="image" src="https://github.com/user-attachments/assets/70dc6bb6-ee16-4d8d-9971-1c91a4416dc2" />

___

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for connection/session failures.
  * More reliable resource cleanup on shutdown to ensure main-thread destruction.

* **Chores**
  * Expanded Android media/codec/plugin support for broader format and decoder coverage.
  * Consistent Android plugin registration at startup.
  * Build/tooling robustness: environment handling improved and release build disabling code/resource shrinking.

* **Other**
  * App now requests INTERNET permission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->